### PR TITLE
Add revision date to prior revision in pagechange

### DIFF
--- a/page_change.go
+++ b/page_change.go
@@ -60,7 +60,8 @@ type PageChange struct {
 				PageNamespace int    `json:"namespace_id"`
 			} `json:"page"`
 			Revision struct {
-				RevID int64 `json:"rev_id"`
+				RevID int64     `json:"rev_id"`
+				RevDt time.Time `json:"rev_dt"`
 			} `json:"revision"`
 		} `json:"prior_state"`
 		Database string `json:"wiki_id"`

--- a/page_change_test.go
+++ b/page_change_test.go
@@ -20,6 +20,10 @@ var pgPageChangeTestEditorRegistrationDt = func() time.Time {
 	t, _ := time.Parse(time.RFC3339, "2024-09-02T20:45:03Z")
 	return t
 }()
+var pgPageChangeTestPriorStateRevDt = func() time.Time {
+	t, _ := time.Parse(time.RFC3339, "2024-09-04T18:34:08Z")
+	return t
+}()
 var pgPageChangeTestResponse = map[int64]struct {
 	Topic     string
 	PageTitle string
@@ -32,6 +36,7 @@ var pgPageChangeTestResponse = map[int64]struct {
 		UserRegistrationDt time.Time
 		UserEditCount      int
 	}
+	PriorStateRevDt time.Time
 }{
 	72231974: {
 		Topic:     "eqiad.mediawiki.page-change",
@@ -62,6 +67,7 @@ var pgPageChangeTestResponse = map[int64]struct {
 			UserRegistrationDt: pgPageChangeTestEditorRegistrationDt,
 			UserEditCount:      10,
 		},
+		PriorStateRevDt: pgPageChangeTestPriorStateRevDt,
 	},
 }
 var pgPageChangeLargeRevIDTestResponse = map[int64]struct {
@@ -158,12 +164,16 @@ func testPgChangeEvent(t *testing.T, evt *PageChange) {
 	assert.Equal(t, expected.PageTitle, evt.Data.Page.PageTitle)
 	assert.Equal(t, expected.RevID, evt.Data.Revision.RevID)
 
-	assert.Equal(t, expected.Editor.UserText, evt.Data.Revision.Editor.UserText)
-	assert.Equal(t, expected.Editor.UserGroups, evt.Data.Revision.Editor.UserGroups)
-	assert.Equal(t, expected.Editor.UserIsBot, evt.Data.Revision.Editor.UserIsBot)
-	assert.Equal(t, expected.Editor.UserID, evt.Data.Revision.Editor.UserID)
-	assert.Equal(t, expected.Editor.UserRegistrationDt, evt.Data.Revision.Editor.UserRegistrationDt)
-	assert.Equal(t, expected.Editor.UserEditCount, evt.Data.Revision.Editor.UserEditCount)
+	if expected.Editor.UserText != "" {
+		assert.Equal(t, expected.Editor.UserText, evt.Data.Revision.Editor.UserText)
+		assert.Equal(t, expected.Editor.UserGroups, evt.Data.Revision.Editor.UserGroups)
+		assert.Equal(t, expected.Editor.UserIsBot, evt.Data.Revision.Editor.UserIsBot)
+		assert.Equal(t, expected.Editor.UserID, evt.Data.Revision.Editor.UserID)
+		assert.Equal(t, expected.Editor.UserRegistrationDt, evt.Data.Revision.Editor.UserRegistrationDt)
+		assert.Equal(t, expected.Editor.UserEditCount, evt.Data.Revision.Editor.UserEditCount)
+	}
+
+	assert.Equal(t, expected.PriorStateRevDt, evt.Data.PriorState.Revision.RevDt)
 }
 
 func TestPgPageChangeExec(t *testing.T) {

--- a/page_change_test.go
+++ b/page_change_test.go
@@ -27,7 +27,7 @@ var pgPageChangeTestPriorStateRevDt = func() time.Time {
 var pgPageChangeTestResponse = map[int64]struct {
 	Topic     string
 	PageTitle string
-	RevID     int
+	RevID     int64
 	Editor    struct {
 		UserText           string
 		UserGroups         []string
@@ -73,7 +73,7 @@ var pgPageChangeTestResponse = map[int64]struct {
 var pgPageChangeLargeRevIDTestResponse = map[int64]struct {
 	Topic     string
 	PageTitle string
-	RevID     int
+	RevID     int64
 	Editor    struct {
 		UserText           string
 		UserGroups         []string
@@ -164,14 +164,12 @@ func testPgChangeEvent(t *testing.T, evt *PageChange) {
 	assert.Equal(t, expected.PageTitle, evt.Data.Page.PageTitle)
 	assert.Equal(t, expected.RevID, evt.Data.Revision.RevID)
 
-	if expected.Editor.UserText != "" {
-		assert.Equal(t, expected.Editor.UserText, evt.Data.Revision.Editor.UserText)
-		assert.Equal(t, expected.Editor.UserGroups, evt.Data.Revision.Editor.UserGroups)
-		assert.Equal(t, expected.Editor.UserIsBot, evt.Data.Revision.Editor.UserIsBot)
-		assert.Equal(t, expected.Editor.UserID, evt.Data.Revision.Editor.UserID)
-		assert.Equal(t, expected.Editor.UserRegistrationDt, evt.Data.Revision.Editor.UserRegistrationDt)
-		assert.Equal(t, expected.Editor.UserEditCount, evt.Data.Revision.Editor.UserEditCount)
-	}
+	assert.Equal(t, expected.Editor.UserText, evt.Data.Revision.Editor.UserText)
+	assert.Equal(t, expected.Editor.UserGroups, evt.Data.Revision.Editor.UserGroups)
+	assert.Equal(t, expected.Editor.UserIsBot, evt.Data.Revision.Editor.UserIsBot)
+	assert.Equal(t, expected.Editor.UserID, evt.Data.Revision.Editor.UserID)
+	assert.Equal(t, expected.Editor.UserRegistrationDt, evt.Data.Revision.Editor.UserRegistrationDt)
+	assert.Equal(t, expected.Editor.UserEditCount, evt.Data.Revision.Editor.UserEditCount)
 
 	assert.Equal(t, expected.PriorStateRevDt, evt.Data.PriorState.Revision.RevDt)
 }
@@ -335,7 +333,7 @@ func TestPgPageChangeLargeRevisionID(t *testing.T) {
 		assert.Equal(t, expected.Topic, (*evt).ID[0].Topic)
 		assert.Equal(t, expected.PageTitle, evt.Data.Page.PageTitle)
 		assert.Equal(t, expected.RevID, evt.Data.Revision.RevID, "RevID should be 5000000000 without downcasting")
-		assert.Greater(t, evt.Data.Revision.RevID, int(1<<32), "RevID should be greater than 2^32")
+		assert.Greater(t, evt.Data.Revision.RevID, int64(1<<32), "RevID should be greater than 2^32")
 
 		assert.Equal(t, expected.Editor.UserText, evt.Data.Revision.Editor.UserText)
 		assert.Equal(t, expected.Editor.UserGroups, evt.Data.Revision.Editor.UserGroups)

--- a/testdata/page-change-large-revid.json
+++ b/testdata/page-change-large-revid.json
@@ -1,2 +1,68 @@
-{"id":[{"topic":"eqiad.mediawiki.page-change","partition":0,"timestamp":1725954560,"offset":516188566}],"data":{"page":{"page_id":77777155,"page_title":"Varvara_Prohorova","namespace_id":0,"is_redirect":false},"revision":{"rev_id":5000000000,"rev_dt":"2024-09-12T06:58:34Z","is_minor_edit":true,"rev_sha1":"6rpcn3pnyzo5zo1k3h92i4cry775thy","rev_size":17652,"rev_parent_id":1244038894,"comment":"Moved page from draft to main namespace","editor":{"user_text":"Svidrigayloff","groups":["*","user","autoconfirmed"],"is_bot":false,"is_system":false,"is_temp":false,"user_id":48379723,"registration_dt":"2024-09-02T20:45:03Z","edit_count":10},"is_content_visible":true,"is_editor_visible":true,"is_comment_visible":true},"performer":{"user_text":"Svidrigayloff","groups":["*","user","autoconfirmed"],"is_bot":false,"is_system":false,"is_temp":false,"user_id":48379723,"registration_dt":"2024-09-02T20:45:03Z","edit_count":10},"comment":"Moved page","meta":{"dt":"2024-09-12T06:58:40Z","stream":"mediawiki.page_change.v1","uri":"https://en.wikipedia.org/wiki/Varvara_Prohorova","request_id":"ab8b5b79-a8b2-4f4e-b491-f313864273c1","domain":"en.wikipedia.org"}}}
-
+[
+    {
+        "id": [
+            {
+                "topic": "eqiad.mediawiki.page-change",
+                "partition": 0,
+                "timestamp": 1725954560,
+                "offset": 516188566
+            }
+        ],
+        "data": {
+            "page": {
+                "page_id": 77777155,
+                "page_title": "Varvara_Prohorova",
+                "namespace_id": 0,
+                "is_redirect": false
+            },
+            "revision": {
+                "rev_id": 5000000000,
+                "rev_dt": "2024-09-12T06:58:34Z",
+                "is_minor_edit": true,
+                "rev_sha1": "6rpcn3pnyzo5zo1k3h92i4cry775thy",
+                "rev_size": 17652,
+                "rev_parent_id": 1244038894,
+                "comment": "Moved page from draft to main namespace",
+                "editor": {
+                    "user_text": "Svidrigayloff",
+                    "groups": [
+                        "*",
+                        "user",
+                        "autoconfirmed"
+                    ],
+                    "is_bot": false,
+                    "is_system": false,
+                    "is_temp": false,
+                    "user_id": 48379723,
+                    "registration_dt": "2024-09-02T20:45:03Z",
+                    "edit_count": 10
+                },
+                "is_content_visible": true,
+                "is_editor_visible": true,
+                "is_comment_visible": true
+            },
+            "performer": {
+                "user_text": "Svidrigayloff",
+                "groups": [
+                    "*",
+                    "user",
+                    "autoconfirmed"
+                ],
+                "is_bot": false,
+                "is_system": false,
+                "is_temp": false,
+                "user_id": 48379723,
+                "registration_dt": "2024-09-02T20:45:03Z",
+                "edit_count": 10
+            },
+            "comment": "Moved page",
+            "meta": {
+                "dt": "2024-09-12T06:58:40Z",
+                "stream": "mediawiki.page_change.v1",
+                "uri": "https://en.wikipedia.org/wiki/Varvara_Prohorova",
+                "request_id": "ab8b5b79-a8b2-4f4e-b491-f313864273c1",
+                "domain": "en.wikipedia.org"
+            }
+        }
+    }
+]


### PR DESCRIPTION
The rev_dt attribute is added to pagechange so it can be propogated in event-stream and used as date_previously_modified. 